### PR TITLE
MusicSystem.cs bug fix and logic update

### DIFF
--- a/LSDR/Assets/Scripts/Audio/MusicSystem.cs
+++ b/LSDR/Assets/Scripts/Audio/MusicSystem.cs
@@ -42,10 +42,19 @@ namespace LSDR.Audio
         {
             var filename = Path.GetFileNameWithoutExtension(filePath);
             if (filename != null)
+            if (filename.Contains(" - "))
             {
-                var splitFilename = filename.Split(new[] {" - "}, 2, StringSplitOptions.RemoveEmptyEntries);
-                CurrentArtist = splitFilename[0];
-                CurrentSong = splitFilename[1];
+                {
+                   var splitFilename = filename.Split(new[] {" - "}, 2, StringSplitOptions.RemoveEmptyEntries);
+                   CurrentArtist = splitFilename[0];
+                   CurrentSong = splitFilename[1];
+                   return;
+                }
+            }
+            else
+            {
+                CurrentArtist = "UNKNOWN ARTIST";
+                CurrentSong = filename;
             }
         }
     }

--- a/LSDR/Assets/Scripts/Audio/MusicSystem.cs
+++ b/LSDR/Assets/Scripts/Audio/MusicSystem.cs
@@ -15,6 +15,7 @@ namespace LSDR.Audio
         public string CurrentSong { get; private set; }
         public string CurrentArtist { get; private set; }
         
+        //DEPRECATED: Torii implementation
         public AudioSource PlayRandomSongFromDirectory(string dir)
         {
             var clip = getRandomSongFromDirectory(dir);
@@ -24,6 +25,14 @@ namespace LSDR.Audio
         public AudioSource PlayRandomSongFromDirectory(AudioSource source, string dir)
         {
             var clip = getRandomSongFromDirectory(dir);
+            
+            if (clip == source.clip)
+			{
+				while (clip == source.clip)
+				{
+					clip = getRandomSongFromDirectory(dir);
+				}
+			}
             source.clip = clip;
             source.Play();
             return source;


### PR DESCRIPTION
Fixed bug: Songs only support "Artist - Song" format, if " - " isn't found, the entire filename is set as the current song, and the current artist is set to "UNKNOWN ARTIST"

Added: Prevents next track from being the same track that's currently playing. This is built on the assumption that there are more then 1 songs in the directory, otherwise it will get stuck in an infinite loop.